### PR TITLE
Add otherArgs method to pass custom ffmpeg options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
-dist-ssr
+# dist
+# dist-ssr
 *.local
 
 # Editor directories and files

--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ const result: Uint8Array | undefined = ffmpeg
   .export();
 ```
 
+Need to supply additional FFmpeg flags? Use `otherArgs`:
+
+```typescript
+const command = await ffmpeg
+  .input({ source: file })
+  .input({ source: overlay })
+  .complexFilter('overlay=0:0')
+  .otherArgs(['-progress', '-', '-v', 'error', '-y'])
+  .ouput({ format: 'mp4', path: 'output.mp4' })
+  .command();
+```
+
 > If you were wondering, yes the memory is being managed for you.
 
 ## 📖 Examples

--- a/dist/ffmpeg-base.d.ts
+++ b/dist/ffmpeg-base.d.ts
@@ -1,0 +1,87 @@
+import * as types from './types';
+export declare class FFmpegBase {
+    private _module;
+    private _ffmpeg;
+    private _logger;
+    private _source;
+    private _uris?;
+    private _whenReady;
+    private _whenExecutionDone;
+    private _onMessage;
+    private _onProgress;
+    private _memory;
+    /**
+     * Is true when the script has been
+     * loaded successfully
+     */
+    isReady: boolean;
+    constructor({ logger, source }: types.FFmpegBaseSettings);
+    /**
+     * Handles the ffmpeg logs
+     */
+    private handleMessage;
+    private handleScriptLoadError;
+    private createScriptURIs;
+    private handleLocateFile;
+    private handleScriptLoad;
+    private createFFmpegScript;
+    /**
+     * Gets called when ffmpeg has been
+     * initiated successfully and is ready
+     * to receive commands
+     */
+    whenReady(cb: types.EventCallback): void;
+    /**
+     * Gets called when ffmpeg is done executing
+     * a script
+     */
+    whenExecutionDone(cb: types.EventCallback): void;
+    /**
+     * Gets called when ffmpeg logs a message
+     */
+    onMessage(cb: types.MessageCallback): void;
+    /**
+     * Remove the callback function from the
+     * message callbacks
+     */
+    removeOnMessage(cb: types.MessageCallback): void;
+    /**
+     * Gets called when a number of frames
+     * has been rendered
+     */
+    onProgress(cb: types.ProgressCallback): void;
+    /**
+     * Remove the callback function from the
+     * progress callbacks
+     */
+    removeOnProgress(cb: types.ProgressCallback): void;
+    /**
+     * Use this message to execute ffmpeg commands
+     */
+    exec(args: string[]): Promise<void>;
+    /**
+     * This method allocates memory required
+     * to execute the command
+     */
+    private parseArgs;
+    /**
+     * Read a file that is stored in the memfs
+     */
+    readFile(path: string): Uint8Array;
+    /**
+     * Delete a file that is stored in the memfs
+     */
+    deleteFile(path: string): void;
+    /**
+     * Write a file to the memfs, the first argument
+     * is the file name to use. The second argument
+     * needs to contain an url to the file or the file
+     * as a blob
+     */
+    writeFile(path: string, file: string | Blob): Promise<void>;
+    /**
+     * Call this method to delete all files that
+     * have been written to the memfs memory
+     */
+    clearMemory(): void;
+}

--- a/dist/ffmpeg-config.d.ts
+++ b/dist/ffmpeg-config.d.ts
@@ -1,0 +1,5 @@
+declare const _default: {
+    'lgpl-base': string;
+    'gpl-extended': string;
+};
+export default _default;

--- a/dist/ffmpeg-js.js
+++ b/dist/ffmpeg-js.js
@@ -1,0 +1,484 @@
+var g = Object.defineProperty;
+var w = (o, t, e) => t in o ? g(o, t, { enumerable: !0, configurable: !0, writable: !0, value: e }) : o[t] = e;
+var h = (o, t, e) => (w(o, typeof t != "symbol" ? t + "" : t, e), e);
+const b = async (o) => {
+  let t;
+  return typeof o == "string" ? t = await (await fetch(o)).arrayBuffer() : t = await await o.arrayBuffer(), new Uint8Array(t);
+}, d = async (o) => {
+  var i;
+  const t = {
+    js: "application/javascript",
+    wasm: "application/wasm"
+  }, e = await (await fetch(o)).arrayBuffer(), s = new Blob([e], {
+    type: t[((i = o.split(".")) == null ? void 0 : i.at(-1)) ?? "js"]
+  });
+  return URL.createObjectURL(s);
+}, _ = (o, ...t) => {
+}, y = (o) => {
+  var e, s, i;
+  const t = (i = (s = (e = o.match(/(^frame=)(\W)*([0-9]{1,})(\W)/)) == null ? void 0 : e.at(0)) == null ? void 0 : s.replace(/frame=/, "")) == null ? void 0 : i.trim();
+  return parseInt(t ?? "0");
+}, F = (o) => (t) => {
+  var e, s, i, r, a, c, n, m;
+  if (t.match(/Input #/) && Object.assign(o, {
+    formats: t.replace(/(Input #|from 'probe')/gm, "").split(",").map((u) => u.trim()).filter((u) => u.length > 1)
+  }), t.match(/Duration:/)) {
+    const u = t.split(",");
+    for (const f of u) {
+      if (f.match(/Duration:/)) {
+        const p = f.replace(/Duration:/, "").trim();
+        Object.assign(o, {
+          duration: Date.parse(`01 Jan 1970 ${p} GMT`) / 1e3
+        });
+      }
+      if (f.match(/bitrate:/)) {
+        const p = f.replace(/bitrate:/, "").trim();
+        Object.assign(o, { bitrate: p });
+      }
+    }
+  }
+  if (t.match(/Stream #/)) {
+    const u = t.split(","), f = {
+      id: (s = (e = u == null ? void 0 : u.at(0)) == null ? void 0 : e.match(/[0-9]{1,2}:[0-9]{1,2}/)) == null ? void 0 : s.at(0)
+    };
+    if (t.match(/Video/)) {
+      const p = f;
+      for (const l of u)
+        l.match(/Video:/) && Object.assign(p, {
+          codec: (a = (r = (i = l.match(/Video:\W*[a-z0-9_-]*\W/i)) == null ? void 0 : i.at(0)) == null ? void 0 : r.replace(/Video:/, "")) == null ? void 0 : a.trim()
+        }), l.match(/[0-9]*x[0-9]*/) && (Object.assign(p, { width: parseFloat(l.split("x")[0]) }), Object.assign(p, { height: parseFloat(l.split("x")[1]) })), l.match(/fps/) && Object.assign(p, {
+          fps: parseFloat(l.replace("fps", "").trim())
+        });
+      o.streams.video.push(p);
+    }
+    if (t.match(/Audio/)) {
+      const p = f;
+      for (const l of u)
+        l.match(/Audio:/) && Object.assign(p, {
+          codec: (m = (n = (c = l.match(/Audio:\W*[a-z0-9_-]*\W/i)) == null ? void 0 : c.at(0)) == null ? void 0 : n.replace(/Audio:/, "")) == null ? void 0 : m.trim()
+        }), l.match(/hz/i) && Object.assign(p, {
+          sampleRate: parseInt(l.replace(/[\D]/gm, ""))
+        });
+      o.streams.audio.push(p);
+    }
+  }
+};
+class E {
+  constructor({ logger: t, source: e }) {
+    h(this, "_module");
+    h(this, "_ffmpeg");
+    h(this, "_logger", _);
+    h(this, "_source");
+    h(this, "_uris");
+    h(this, "_whenReady", []);
+    h(this, "_whenExecutionDone", []);
+    h(this, "_onMessage", []);
+    h(this, "_onProgress", []);
+    h(this, "_memory", []);
+    /**
+     * Is true when the script has been
+     * loaded successfully
+     */
+    h(this, "isReady", !1);
+    this._source = e, this._logger = t, this.createFFmpegScript();
+  }
+  /**
+   * Handles the ffmpeg logs
+   */
+  handleMessage(t) {
+    this._logger(t), t.match(/(FFMPEG_END|error)/i) && this._whenExecutionDone.forEach((e) => e()), t.match(/^frame=/) && this._onProgress.forEach((e) => e(y(t))), this._onMessage.forEach((e) => e(t));
+  }
+  handleScriptLoadError() {
+    this._logger("Failed to load script!");
+  }
+  async createScriptURIs() {
+    return {
+      core: await d(this._source),
+      wasm: await d(this._source.replace(".js", ".wasm")),
+      worker: await d(this._source.replace(".js", ".worker.js"))
+    };
+  }
+  handleLocateFile(t, e) {
+    var s, i;
+    return t.endsWith("ffmpeg-core.wasm") ? (s = this._uris) == null ? void 0 : s.wasm : t.endsWith("ffmpeg-core.worker.js") ? (i = this._uris) == null ? void 0 : i.worker : e + t;
+  }
+  async handleScriptLoad() {
+    var e;
+    const t = await createFFmpegCore({
+      mainScriptUrlOrBlob: (e = this._uris) == null ? void 0 : e.core,
+      printErr: this.handleMessage.bind(this),
+      print: this.handleMessage.bind(this),
+      locateFile: this.handleLocateFile.bind(this)
+    });
+    this._logger("CREATED FFMPEG WASM:", t), this.isReady = !0, this._module = t, this._ffmpeg = this._module.cwrap("proxy_main", "number", [
+      "number",
+      "number"
+    ]), this._whenReady.forEach((s) => s());
+  }
+  async createFFmpegScript() {
+    const t = document.createElement("script");
+    this._uris = await this.createScriptURIs(), t.src = this._uris.core, t.type = "text/javascript", t.addEventListener("load", this.handleScriptLoad.bind(this)), t.addEventListener("error", this.handleScriptLoadError.bind(this)), document.head.appendChild(t);
+  }
+  /**
+   * Gets called when ffmpeg has been
+   * initiated successfully and is ready
+   * to receive commands
+   */
+  whenReady(t) {
+    this.isReady ? t() : this._whenReady.push(t);
+  }
+  /**
+   * Gets called when ffmpeg is done executing
+   * a script
+   */
+  whenExecutionDone(t) {
+    this._whenExecutionDone.push(t);
+  }
+  /**
+   * Gets called when ffmpeg logs a message
+   */
+  onMessage(t) {
+    this._onMessage.push(t);
+  }
+  /**
+   * Remove the callback function from the
+   * message callbacks
+   */
+  removeOnMessage(t) {
+    this._onMessage = this._onMessage.filter((e) => e != t);
+  }
+  /**
+   * Gets called when a number of frames
+   * has been rendered
+   */
+  onProgress(t) {
+    this._onProgress.push(t);
+  }
+  /**
+   * Remove the callback function from the
+   * progress callbacks
+   */
+  removeOnProgress(t) {
+    this._onProgress = this._onProgress.filter((e) => e != t);
+  }
+  /**
+   * Use this message to execute ffmpeg commands
+   */
+  async exec(t) {
+    var e;
+    this._ffmpeg(...this.parseArgs(["./ffmpeg", "-nostdin", "-y", ...t])), await new Promise((s) => {
+      this.whenExecutionDone(s);
+    }), (e = t.at(-1)) != null && e.match(/\S\.[A-Za-z0-9_-]{1,20}/) && this._memory.push(t.at(-1) ?? "");
+  }
+  /**
+   * This method allocates memory required
+   * to execute the command
+   */
+  parseArgs(t) {
+    const e = this._module._malloc(
+      t.length * Uint32Array.BYTES_PER_ELEMENT
+    );
+    return t.forEach((s, i) => {
+      const r = this._module.lengthBytesUTF8(s) + 1, a = this._module._malloc(r);
+      this._module.stringToUTF8(s, a, r), this._module.setValue(
+        e + Uint32Array.BYTES_PER_ELEMENT * i,
+        a,
+        "i32"
+      );
+    }), [t.length, e];
+  }
+  /**
+   * Read a file that is stored in the memfs
+   */
+  readFile(t) {
+    return this._logger("READING FILE:", t), this._module.FS.readFile(t);
+  }
+  /**
+   * Delete a file that is stored in the memfs
+   */
+  deleteFile(t) {
+    try {
+      this._logger("DELETING FILE:", t), this._module.FS.unlink(t);
+    } catch {
+      this._logger("Could not delete file");
+    }
+  }
+  /**
+   * Write a file to the memfs, the first argument
+   * is the file name to use. The second argument
+   * needs to contain an url to the file or the file
+   * as a blob
+   */
+  async writeFile(t, e) {
+    const s = await b(e);
+    this._logger("WRITING FILE:", t), this._module.FS.writeFile(t, s), this._memory.push(t);
+  }
+  /**
+   * Call this method to delete all files that
+   * have been written to the memfs memory
+   */
+  clearMemory() {
+    for (const t of [...new Set(this._memory)])
+      this.deleteFile(t);
+    this._memory = [];
+  }
+}
+const S = {
+  "lgpl-base": "https://unpkg.com/@diffusion-studio/ffmpeg-lgpl-base@0.0.1/dist/ffmpeg-core.js",
+  "gpl-extended": "https://unpkg.com/@ffmpeg/core@0.11.0/dist/ffmpeg-core.js"
+};
+class O extends E {
+  constructor(e = {}) {
+    let s = console.log, i = S[(e == null ? void 0 : e.config) ?? "lgpl-base"];
+    (e == null ? void 0 : e.log) == !1 && (s = _), e != null && e.source && (i = e.source);
+    super({ logger: s, source: i });
+    h(this, "_inputs", []);
+    h(this, "_output");
+    h(this, "_middleware", []);
+  }
+  /**
+   * Get all supported video decoders, encoders and
+   * audio decoder, encoders. You can test if a codec
+   * is available like so:
+   * @example
+   * const codecs = await ffmpeg.codecs();
+   *
+   * if ("aac" in codecs.audio.encoders) {
+   *  // do something
+   * }
+   */
+  async codecs() {
+    const e = {
+      encoders: {},
+      decoders: {}
+    }, s = {
+      video: JSON.parse(JSON.stringify(e)),
+      audio: JSON.parse(JSON.stringify(e))
+    }, i = (r) => {
+      r = r.substring(7).replace(/\W{2,}/, " ").trim();
+      const a = r.split(" "), c = a.shift() ?? "", n = a.join(" ");
+      return { [c]: n };
+    };
+    return this.onMessage((r) => {
+      r = r.trim();
+      let a = [];
+      if (r.match(/[DEVASIL\.]{6}\W(?!=)/)) {
+        r.match(/^D.V/) && a.push(["video", "decoders"]), r.match(/^.EV/) && a.push(["video", "encoders"]), r.match(/^D.A/) && a.push(["audio", "decoders"]), r.match(/^.EA/) && a.push(["audio", "encoders"]);
+        for (const [c, n] of a)
+          Object.assign(s[c][n], i(r));
+      }
+    }), await this.exec(["-codecs"]), s;
+  }
+  /**
+   * Get all supported muxers and demuxers, e.g. mp3, webm etc.
+   * You can test if a format is available like this:
+   * @example
+   * const formats = await ffmpeg.formats();
+   *
+   * if ("mp3" in formats.demuxers) {
+   *  // do something
+   * }
+   */
+  async formats() {
+    const e = {
+      muxers: {},
+      demuxers: {}
+    }, s = (i) => {
+      i = i.substring(3).replace(/\W{2,}/, " ").trim();
+      const r = i.split(" "), a = r.shift() ?? "", c = r.join(" ");
+      return { [a]: c };
+    };
+    return this.onMessage((i) => {
+      i = i.substring(1);
+      let r = [];
+      if (i.match(/[DE\.]{2}\W(?!=)/)) {
+        i.match(/^D./) && r.push("demuxers"), i.match(/^.E/) && r.push("muxers");
+        for (const a of r)
+          Object.assign(e[a], s(i));
+      }
+    }), await this.exec(["-formats"]), e;
+  }
+  /**
+   * Add a new input using the specified options
+   */
+  input(e) {
+    return (this._middleware.length > 0 || this._output) && (this._inputs = [], this._middleware = [], this._output = void 0, this.clearMemory()), this._inputs.push(e), this;
+  }
+  /**
+   * Define the ouput format
+   */
+  ouput(e) {
+    return this._output = e, this;
+  }
+  /**
+   * Add an audio filter [see](https://ffmpeg.org/ffmpeg-filters.html#Audio-Filters)
+   * for more information
+   */
+  audioFilter(e) {
+    if (this._middleware.push("-af", e), this._inputs.length > 1)
+      throw new Error(
+        "Cannot use filters on multiple outputs, please use filterComplex instead"
+      );
+    return this;
+  }
+  /**
+   * Add an video filter [see](https://ffmpeg.org/ffmpeg-filters.html#Video-Filters)
+   * for more information
+   */
+  videoFilter(e) {
+    if (this._middleware.push("-vf", e), this._inputs.length > 1)
+      throw new Error(
+        "Cannot use filters on multiple outputs, please use filterComplex instead"
+      );
+    return this;
+  }
+  /**
+   * Add a complex filter to multiple videos [see](https://ffmpeg.org/ffmpeg-filters.html)
+   * for more information
+   */
+  complexFilter(e) {
+    return this._middleware.push("-filter_complex", e), this;
+  }
+  /**
+   * Choose which input should be inclueded in the output [see](https://trac.ffmpeg.org/wiki/Map)
+   * for more information
+   */
+  map(e) {
+    return this._middleware.push("-map", e), this;
+  }
+  /**
+   * Append additional ffmpeg arguments that are not covered by
+   * the convenience methods.
+   */
+  otherArgs(e) {
+    return this._middleware.push(...e), this;
+  }
+  /**
+   * Get the ffmpeg command from the specified
+   * inputs and outputs.
+   */
+  async command() {
+    const e = [];
+    return e.push(...await this.parseInputOptions()), e.push(...this._middleware), e.push(...await this.parseOutputOptions()), e;
+  }
+  /**
+   * Exports the specified input(s)
+   */
+  async export() {
+    const e = await this.command();
+    await this.exec(e);
+    const s = this.readFile(e.at(-1) ?? "");
+    return this.clearMemory(), s;
+  }
+  /**
+   * Get the meta data of a the specified file.
+   * Returns information such as codecs, fps, bitrate etc.
+   */
+  async meta(e) {
+    await this.writeFile("probe", e);
+    const s = {
+      streams: { audio: [], video: [] }
+    }, i = F(s);
+    return this.onMessage(i), await this.exec(["-i", "probe"]), this.removeOnMessage(i), this.clearMemory(), s;
+  }
+  /**
+   * Generate a series of thumbnails
+   * @param source Your input file
+   * @param count The number of thumbnails to generate
+   * @param start Lower time limit in seconds
+   * @param stop Upper time limit in seconds
+   * @example
+   * // type AsyncGenerator<Blob, void, void>
+   * const generator = ffmpeg.thumbnails('/samples/video.mp4');
+   *
+   * for await (const image of generator) {
+   *    const img = document.createElement('img');
+   *    img.src = URL.createObjectURL(image);
+   *    document.body.appendChild(img);
+   * }
+   */
+  async *thumbnails(e, s = 5, i = 0, r) {
+    if (!r) {
+      const { duration: c } = await this.meta(e);
+      c ? r = c : (console.warn(
+        "Could not extract duration from meta data please provide a stop argument. Falling back to 1sec otherwise."
+      ), r = 1);
+    }
+    const a = (r - i) / s;
+    await this.writeFile("input", e);
+    for (let c = i; c < r; c += a) {
+      await this.exec([
+        "-ss",
+        c.toString(),
+        "-i",
+        "input",
+        "-frames:v",
+        "1",
+        "image.jpg"
+      ]);
+      try {
+        const n = await this.readFile("image.jpg");
+        yield new Blob([n], { type: "image/jpeg" });
+      } catch {
+      }
+    }
+    this.clearMemory();
+  }
+  parseOutputOptions() {
+    if (!this._output)
+      throw new Error("Please define the output first");
+    const { format: e, path: s, audio: i, video: r, seek: a, duration: c } = this._output, n = [];
+    let m = `output.${e}`;
+    return s && (m = s + m), a && n.push("-ss", a.toString()), c && n.push("-t", c.toString()), n.push(...this.parseAudioOutput(i)), n.push(...this.parseVideoOutput(r)), n.push(m), n;
+  }
+  parseAudioOutput(e) {
+    if (!e)
+      return [];
+    if ("disableAudio" in e)
+      return e.disableAudio ? ["-an"] : [];
+    const s = [];
+    return e.codec && s.push("-c:a", e.codec), e.bitrate && s.push("-b:a", e.bitrate.toString()), e.numberOfChannels && s.push("-ac", e.numberOfChannels.toString()), e.volume && s.push("-vol", e.volume.toString()), e.sampleRate && s.push("-ar", e.sampleRate.toString()), s;
+  }
+  parseVideoOutput(e) {
+    if (!e)
+      return [];
+    if ("disableVideo" in e)
+      return e.disableVideo ? ["-vn"] : [];
+    const s = [];
+    return e.codec && s.push("-c:v", e.codec), e.bitrate && s.push("-b:v", e.bitrate.toString()), e.aspectRatio && s.push("-aspect", e.aspectRatio.toString()), e.framerate && s.push("-r", e.framerate.toString()), e.size && s.push("-s", `${e.size.width}x${e.size.height}`), s;
+  }
+  async parseInputOptions() {
+    const e = [];
+    for (const s of this._inputs)
+      e.push(...await this.parseImageInput(s)), e.push(...await this.parseMediaInput(s));
+    return e;
+  }
+  async parseImageInput(e) {
+    if (!("sequence" in e))
+      return [];
+    const s = e.sequence.length.toString().length, i = "image-sequence-";
+    let r = `${i}%0${s}d`;
+    const a = [];
+    for (const [c, n] of e.sequence.entries())
+      if (n instanceof Blob || n.match(/(^http(s?):\/\/|^\/\S)/)) {
+        const m = `${i}${c.toString().padStart(c, "0")}`;
+        await this.writeFile(m, n);
+      } else {
+        const m = n.match(/[0-9]{1,20}/);
+        if (m) {
+          const [u] = m;
+          r = n.replace(/[0-9]{1,20}/, `%0${u.length}d`);
+        }
+      }
+    return a.push("-framerate", e.framerate.toString()), a.push("-i", r), a;
+  }
+  async parseMediaInput(e) {
+    if (!("source" in e))
+      return [];
+    const { source: s } = e, i = [], r = `input-${(/* @__PURE__ */ new Date()).getTime()}`;
+    return e.seek && i.push("-ss", e.seek.toString()), s instanceof Blob || s.match(/(^http(s?):\/\/|^\/\S)/) ? (await this.writeFile(r, s), i.push("-i", r)) : i.push("-i", s), i;
+  }
+}
+export {
+  O as FFmpeg
+};

--- a/dist/ffmpeg.d.ts
+++ b/dist/ffmpeg.d.ts
@@ -1,0 +1,102 @@
+import { IFFmpegConfiguration } from './interfaces';
+import { FFmpegBase } from './ffmpeg-base';
+import * as types from './types';
+export declare class FFmpeg<Config extends IFFmpegConfiguration<string, string, string> = types.FFmpegConfiguration> extends FFmpegBase {
+    private _inputs;
+    private _output?;
+    private _middleware;
+    constructor(settings?: types.FFmpegSettings);
+    /**
+     * Get all supported video decoders, encoders and
+     * audio decoder, encoders. You can test if a codec
+     * is available like so:
+     * @example
+     * const codecs = await ffmpeg.codecs();
+     *
+     * if ("aac" in codecs.audio.encoders) {
+     *  // do something
+     * }
+     */
+    codecs(): Promise<types.SupportedCodecs>;
+    /**
+     * Get all supported muxers and demuxers, e.g. mp3, webm etc.
+     * You can test if a format is available like this:
+     * @example
+     * const formats = await ffmpeg.formats();
+     *
+     * if ("mp3" in formats.demuxers) {
+     *  // do something
+     * }
+     */
+    formats(): Promise<types.SupportedFormats>;
+    /**
+     * Add a new input using the specified options
+     */
+    input(options: types.InputOptions): this;
+    /**
+     * Define the ouput format
+     */
+    ouput(options: types.OutputOptions<Config>): this;
+    /**
+     * Add an audio filter [see](https://ffmpeg.org/ffmpeg-filters.html#Audio-Filters)
+     * for more information
+     */
+    audioFilter(filter: string): this;
+    /**
+     * Add an video filter [see](https://ffmpeg.org/ffmpeg-filters.html#Video-Filters)
+     * for more information
+     */
+    videoFilter(filter: string): this;
+    /**
+     * Add a complex filter to multiple videos [see](https://ffmpeg.org/ffmpeg-filters.html)
+     * for more information
+     */
+    complexFilter(filter: string): this;
+    /**
+     * Choose which input should be inclueded in the output [see](https://trac.ffmpeg.org/wiki/Map)
+     * for more information
+     */
+    map(input: string): this;
+    /**
+     * Append additional ffmpeg arguments that are not covered by
+     * the convenience methods.
+     */
+    otherArgs(args: string[]): this;
+    /**
+     * Get the ffmpeg command from the specified
+     * inputs and outputs.
+     */
+    command(): Promise<string[]>;
+    /**
+     * Exports the specified input(s)
+     */
+    export(): Promise<Uint8Array | undefined>;
+    /**
+     * Get the meta data of a the specified file.
+     * Returns information such as codecs, fps, bitrate etc.
+     */
+    meta(source: string | Blob): Promise<types.Metadata>;
+    /**
+     * Generate a series of thumbnails
+     * @param source Your input file
+     * @param count The number of thumbnails to generate
+     * @param start Lower time limit in seconds
+     * @param stop Upper time limit in seconds
+     * @example
+     * // type AsyncGenerator<Blob, void, void>
+     * const generator = ffmpeg.thumbnails('/samples/video.mp4');
+     *
+     * for await (const image of generator) {
+     *    const img = document.createElement('img');
+     *    img.src = URL.createObjectURL(image);
+     *    document.body.appendChild(img);
+     * }
+     */
+    thumbnails(source: string | Blob, count?: number, start?: number, stop?: number): AsyncGenerator<Blob, void, void>;
+    private parseOutputOptions;
+    private parseAudioOutput;
+    private parseVideoOutput;
+    private parseInputOptions;
+    private parseImageInput;
+    private parseMediaInput;
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,3 @@
+export * from './ffmpeg';
+export * from './interfaces';
+export * from './types';

--- a/dist/interfaces.d.ts
+++ b/dist/interfaces.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Defines the available configuration extensions
+ */
+export interface IFFmpegConfiguration<EXT, CA, CV> {
+    extensions?: EXT;
+    audioCodecs?: CA;
+    videoCodecs?: CV;
+}

--- a/dist/types/cmd-options.d.ts
+++ b/dist/types/cmd-options.d.ts
@@ -1,0 +1,147 @@
+import { IFFmpegConfiguration } from '../interfaces';
+/**
+ * Defines the available audio output options
+ */
+export type AudioOutputOptions<AudioCodecExtension> = {
+    /**
+     * A string containing a valid audio encoder string. Get the supported
+     * codecs with `ffmpeg.codecs()`. Use `"copy"` to use the input codec.
+     * @example "aac"
+     */
+    codec?: 'copy' | AudioCodecExtension;
+    /**
+     * An integer representing the number of frame
+     * samples per second (Hz).
+     * @example 44100 // Hz
+     */
+    sampleRate?: number;
+    /**
+     * An integer representing the number of audio channels.
+     * @example 2 // stereo
+     */
+    numberOfChannels?: number;
+    /**
+     * An integer containing the average bitrate of the encoded
+     * audio in units of bits per second.
+     * @example 128_000, // 128 kbps
+     */
+    bitrate?: number;
+    /**
+     * A number setting the volume of the output (256=normal).
+     */
+    volume?: number;
+};
+export type DisabledAudioOutput = {
+    /**
+     * Disable all audio tracks.
+     */
+    disableAudio: boolean;
+};
+/**
+ * Defines the available video output options
+ */
+export type VideoOutputOptions<VideoCodecExtension> = {
+    /**
+     * A string containing a valid video encoder string. Get the supported
+     * codecs with `ffmpeg.codecs()`. Use `"copy"` to use the input codec.
+     * @example "h263"
+     */
+    codec?: 'copy' | VideoCodecExtension;
+    /**
+     * A number repersenting the framerate
+     * @example 30 // fps
+     */
+    framerate?: number;
+    /**
+     * A number containing the aspect ratio of the video
+     * @example 16/9 // 16:9
+     */
+    aspectRatio?: number;
+    /**
+     * With and height as numbers defining the video output size
+     * @example { width: 1920, height: 1080}
+     */
+    size?: {
+        width: number;
+        height: number;
+    };
+    /**
+     * An integer containing the average bitrate of the encoded
+     * audio in units of bits per second.
+     * @example 2_000_000, // 2 Mbps
+     */
+    bitrate?: number;
+};
+export type DisabledVideoOutput = {
+    /**
+     * Disable all video tracks.
+     */
+    disableVideo: boolean;
+};
+/**
+ * Defines an image/ image sequence imput
+ */
+export interface ImageOptions {
+    /**
+     * Accepted Formats:
+     * - A URL such as one created with `URL.createObjectURL()`
+     * - A Blob that you can get from the `File API`
+     * - A File path that you have used for the `ffmpeg.writeFile()` method
+     */
+    sequence: (string | Blob)[];
+    /**
+     * If you're using a image sequence, use this parameter
+     * to specify the input framerate
+     */
+    framerate: number;
+}
+/**
+ * Defines an audio / video input
+ */
+export interface MediaOptions {
+    /**
+     * Accepted Formats:
+     * - A URL such as one created with `URL.createObjectURL()`
+     * - A Blob that you can get from the `File API`
+     * - A File path that you have used for the `ffmpeg.writeFile()` method
+     */
+    source: string | Blob;
+    /**
+     * Time offset in seconds from the start of the input
+     */
+    seek?: number;
+}
+/**
+ * Defines how the input is structured
+ */
+export type InputOptions = ImageOptions | MediaOptions;
+/**
+ * Defines the desired output structure
+ */
+export interface OutputOptions<Config extends IFFmpegConfiguration<string, string, string>> {
+    /**
+     * Choose an output format such as mp4 or wav
+     */
+    format: Config['extensions'];
+    /**
+     * Choose a path where to save the output to
+     * (Not relevat in browser environments)
+     */
+    path?: string;
+    /**
+     * Seek a time to start the output in seconds
+     */
+    seek?: number;
+    /**
+     * Set the total duration of the output in seconds
+     */
+    duration?: number;
+    /**
+     * Audio options
+     */
+    audio?: AudioOutputOptions<Config['audioCodecs']> | DisabledAudioOutput;
+    /**
+     * Video options
+     */
+    video?: VideoOutputOptions<Config['videoCodecs']> | DisabledVideoOutput;
+}

--- a/dist/types/common.d.ts
+++ b/dist/types/common.d.ts
@@ -1,0 +1,181 @@
+import configs from '../ffmpeg-config';
+/**
+ * Defines a callback function that
+ * gets triggered by an event
+ */
+export type EventCallback = () => void;
+/**
+ * Defines a callback function that
+ * gets called when ffmpeg logs a message
+ */
+export type MessageCallback = (msg: string) => void;
+/**
+ * Defines a callback function that
+ * gets called during rendering when a number
+ * of frames has been rendered
+ */
+export type ProgressCallback = (progress: number) => void;
+/**
+ * Defines encoder and decoder records that
+ * contain the supported formats
+ */
+export type EncoderDecoderRecords = {
+    encoders: Record<string, string>;
+    decoders: Record<string, string>;
+};
+/**
+ * Defines the supported formats that ffmpeg
+ * has been compiled with.
+ */
+export interface SupportedFormats {
+    muxers: Record<string, string>;
+    demuxers: Record<string, string>;
+}
+/**
+ * Defines the supported video and audio
+ * encoders and decoders that ffmpeg has been
+ * compiled with.
+ */
+export interface SupportedCodecs {
+    /**
+     * Video encoders and decoders dictionary
+     */
+    video: EncoderDecoderRecords;
+    /**
+     * Audio encoders and decoders dictionary
+     */
+    audio: EncoderDecoderRecords;
+}
+/**
+ * Defines the available constructor options
+ */
+export type FFmpegSettings = {
+    /**
+     * Choose a custom ffmpeg binary location
+     * @example
+     * new URL("/dist/ffmpeg-core.js", import.meta.url).href;
+     * // this will retrieve the file from a local location
+     */
+    source?: string;
+    /**
+     * Choose which ffmpeg wasm configuration to use.
+     * **MAKE SURE YOU SELECT THE LICENSE THAT YOU CAN**
+     * **COMPLY WITH**, checkout https://ffmpeg.org/legal.html
+     * for more.
+     */
+    config?: keyof typeof configs;
+    /**
+     * Choose whether ffmpeg should log each output
+     */
+    log?: boolean;
+};
+/**
+ * Defines the available constructor options
+ */
+export type FFmpegBaseSettings = {
+    /**
+     * Overwrite the logging function.
+     */
+    logger(msg?: any, ...params: any[]): void;
+    /**
+     * Choose a custom ffmpeg binary location
+     */
+    source: string;
+};
+/**
+ * Defines the locations of the wasm module
+ */
+export type WasmModuleURIs = {
+    /**
+     * `ffmpeg-core.js` path
+     */
+    core: string;
+    /**
+     * `ffmpeg-core.wasm` path
+     */
+    wasm: string;
+    /**
+     * `ffmpeg-core.worker.js` path
+     */
+    worker: string;
+};
+/**
+ * Defines the metadata of an audio stream
+ */
+export type AudioStream = {
+    /**
+     * String containing the id given
+     * by ffmpeg, e.g. 0:1
+     */
+    id?: string;
+    /**
+     * String containing the audio codec
+     */
+    codec?: string;
+    /**
+     * Number containing the audio sample rate
+     */
+    sampleRate?: number;
+};
+/**
+ * Defines the metadata of a video stream
+ */
+export type VideoStream = {
+    /**
+     * String containing the id given
+     * by ffmpeg, e.g. 0:0
+     */
+    id?: string;
+    /**
+     * String containing the video codec
+     */
+    codec?: string;
+    /**
+     * Number containing the video width
+     */
+    width?: number;
+    /**
+     * Number containing the video height
+     */
+    height?: number;
+    /**
+     * Number containing the fps
+     */
+    fps?: number;
+};
+/**
+ * Defines the metadata of a ffmpeg input log.
+ * These information will be extracted from
+ * the -i command.
+ */
+export type Metadata = {
+    /**
+     * Number containing the duration of the
+     * input in seconds
+     */
+    duration?: number;
+    /**
+     * String containing the bitrate of the file.
+     * E.g 16 kb/s
+     */
+    bitrate?: string;
+    /**
+     * Array of strings containing the applicable
+     * container formats. E.g. mov, mp4, m4a,
+     * 3gp, 3g2, mj2
+     */
+    formats?: string[];
+    /**
+     * Separation in audio and video streams
+     */
+    streams: {
+        /**
+         * Array of audio streams
+         */
+        audio: AudioStream[];
+        /**
+         * Array of video streams
+         */
+        video: VideoStream[];
+    };
+};

--- a/dist/types/gpl-extended.d.ts
+++ b/dist/types/gpl-extended.d.ts
@@ -1,0 +1,21 @@
+import { IFFmpegConfiguration } from '../interfaces';
+/**
+ * Defines all available extensions of the
+ * extended gpl non free ffmpeg configuration.
+ */
+export type ExtensionGPLExtended = 'ac3' | 'adx' | 'aif' | 'aiff' | 'afc' | 'aifc' | 'al' | 'amr' | 'apng' | 'aptx' | 'aptxhd' | 'asf' | 'wmv' | 'wma' | 'ass' | 'ssa' | 'ast' | 'au' | 'avi' | 'avs' | 'avs2' | 'bit' | 'caf' | 'cavs' | 'c2' | '302' | 'drc' | 'vc2' | 'dnxhd' | 'dnxhr' | 'dts' | 'dv' | 'eac3' | 'ffmeta' | 'cpk' | 'flm' | 'fits' | 'flac' | 'flv' | 'g722' | 'tco' | 'rco' | 'gif' | 'gsm' | 'gxf' | 'h261' | 'h263' | 'h264' | '264' | 'hevc' | 'h265' | '265' | 'm3u8' | 'lbc' | 'ivf' | 'vag' | 'm4v' | 'm4a' | 'sub' | 'mjpg' | 'mjpeg' | 'mlp' | 'mmf' | 'mp3' | 'mp4' | 'mpg' | 'mpeg' | 'mkv' | 'mov' | 'ts' | 'm2t' | 'm2ts' | 'mts' | 'ul' | 'mxf' | 'nut' | 'ogg' | 'oma' | 'yuv' | 'rgb' | 'rm' | 'ra' | 'roq' | 'rso' | 'sw' | 'sb' | 'sbc' | 'msbc' | 'scc' | 'sox' | 'spdif' | 'srt' | 'sup' | 'swf' | 'thd' | 'tta' | 'uw' | 'ub' | 'vc1' | 'rcv' | 'voc' | 'w64' | 'wav' | 'xml' | 'vtt' | 'wtv' | 'wv' | 'y4m';
+/**
+ * Defines all available audio encoders of the
+ * extended gpl non free ffmpeg configuration.
+ */
+export type AudioEncoderGPLExtended = 'aac' | 'ac3' | 'adpcm_adx' | 'adpcm_g722' | 'adpcm_g726' | 'adpcm_g726le' | 'adpcm_ima_qt' | 'adpcm_ima_ssi' | 'adpcm_ima_wav' | 'adpcm_ms' | 'adpcm_swf' | 'adpcm_yamaha' | 'alac' | 'aptx' | 'aptx_hd' | 'comfortnoise' | 'dts' | 'eac3' | 'flac' | 'g723_1' | 'mlp' | 'mp2' | 'mp3' | 'nellymoser' | 'opus' | 'pcm_alaw' | 'pcm_dvd' | 'pcm_f32be' | 'pcm_f32le' | 'pcm_f64be' | 'pcm_f64le' | 'pcm_mulaw' | 'pcm_s16be' | 'pcm_s16be_planar' | 'pcm_s16le' | 'pcm_s16le_planar' | 'pcm_s24be' | 'pcm_s24daud' | 'pcm_s24le' | 'pcm_s24le_planar' | 'pcm_s32be' | 'pcm_s32le' | 'pcm_s32le_planar' | 'pcm_s64be' | 'pcm_s64le' | 'pcm_s8' | 'pcm_s8_planar' | 'pcm_u16be' | 'pcm_u16le' | 'pcm_u24be' | 'pcm_u24le' | 'pcm_u32be' | 'pcm_u32le' | 'pcm_u8' | 'pcm_vidc' | 'ra_144' | 'roq_dpcm' | 's302m' | 'sbc' | 'sonic' | 'sonicls' | 'truehd' | 'tta' | 'vorbis' | 'wavpack' | 'wmav1' | 'wmav2';
+/**
+ * Defines all available video encoders of the
+ * extended gpl non free ffmpeg configuration.
+ */
+export type VideoEncoderGPLExtended = 'a64_multi' | 'a64_multi5' | 'alias_pix' | 'amv' | 'apng' | 'asv1' | 'asv2' | 'avrp' | 'avui' | 'ayuv' | 'bmp' | 'cinepak' | 'cljr' | 'dirac' | 'dnxhd' | 'dpx' | 'dvvideo' | 'ffv1' | 'ffvhuff' | 'fits' | 'flashsv' | 'flashsv2' | 'flv1' | 'gif' | 'h261' | 'h263' | 'h263p' | 'h264' | 'hevc' | 'huffyuv' | 'jpeg2000' | 'jpegls' | 'ljpeg' | 'magicyuv' | 'mjpeg' | 'mpeg1video' | 'mpeg2video' | 'mpeg4' | 'msmpeg4v2' | 'msmpeg4v3' | 'msvideo1' | 'pam' | 'pbm' | 'pcx' | 'pgm' | 'pgmyuv' | 'png' | 'ppm' | 'prores' | 'qtrle' | 'r10k' | 'r210' | 'rawvideo' | 'roq' | 'rv10' | 'rv20' | 'sgi' | 'snow' | 'sunrast' | 'svq1' | 'targa' | 'theora' | 'tiff' | 'utvideo' | 'v210' | 'v308' | 'v408' | 'v410' | 'vp8' | 'vp9' | 'webp' | 'wmv1' | 'wmv2' | 'webm' | 'wrapped_avframe' | 'xbm' | 'xface' | 'xwd' | 'y41p' | 'yuv4' | 'zlib' | 'zmbv';
+/**
+ * Defines the typing of the extended gpl
+ * non free ffmpeg configuration.
+ */
+export type FFmpegConfigurationGPLExtended = IFFmpegConfiguration<ExtensionGPLExtended, AudioEncoderGPLExtended, VideoEncoderGPLExtended>;

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -1,0 +1,4 @@
+export * from './gpl-extended';
+export * from './cmd-options';
+export * from './lgpl-base';
+export * from './common';

--- a/dist/types/lgpl-base.d.ts
+++ b/dist/types/lgpl-base.d.ts
@@ -1,0 +1,21 @@
+import { IFFmpegConfiguration } from '../interfaces';
+/**
+ * Defines all available extensions of the
+ * ffmpeg base configuration.
+ */
+export type ExtensionBase = 'ac3' | 'adx' | 'aif' | 'aiff' | 'afc' | 'aifc' | 'al' | 'amr' | 'apng' | 'aptx' | 'aptxhd' | 'asf' | 'wmv' | 'wma' | 'ass' | 'ssa' | 'ast' | 'au' | 'avi' | 'avs' | 'avs2' | 'bit' | 'caf' | 'cavs' | 'c2' | '302' | 'drc' | 'vc2' | 'dnxhd' | 'dnxhr' | 'dts' | 'dv' | 'eac3' | 'ffmeta' | 'cpk' | 'flm' | 'fits' | 'flac' | 'flv' | 'g722' | 'tco' | 'rco' | 'gif' | 'gsm' | 'gxf' | 'h261' | 'h263' | 'h264' | '264' | 'hevc' | 'h265' | '265' | 'm3u8' | 'lbc' | 'ivf' | 'vag' | 'm4v' | 'm4a' | 'sub' | 'mjpg' | 'mjpeg' | 'mlp' | 'mmf' | 'mp3' | 'mp4' | 'mpg' | 'mpeg' | 'mov' | 'mkv' | 'ts' | 'm2t' | 'm2ts' | 'mts' | 'ul' | 'mxf' | 'nut' | 'ogg' | 'oma' | 'yuv' | 'rgb' | 'rm' | 'ra' | 'roq' | 'rso' | 'sw' | 'sb' | 'sbc' | 'msbc' | 'scc' | 'sox' | 'spdif' | 'srt' | 'sup' | 'swf' | 'thd' | 'tta' | 'uw' | 'ub' | 'vc1' | 'rcv' | 'voc' | 'w64' | 'wav' | 'webm' | 'xml' | 'vtt' | 'wtv' | 'wv' | 'y4m';
+/**
+ * Defines all available audio encoders of the
+ * ffmpeg base configuration.
+ */
+export type AudioEncoderBase = 'aac' | 'ac3' | 'adpcm_adx' | 'adpcm_g722' | 'adpcm_g726' | 'adpcm_g726le' | 'adpcm_ima_qt' | 'adpcm_ima_ssi' | 'adpcm_ima_wav' | 'adpcm_ms' | 'adpcm_swf' | 'adpcm_yamaha' | 'alac' | 'aptx' | 'aptx_hd' | 'comfortnoise' | 'dts' | 'eac3' | 'flac' | 'g723_1' | 'mlp' | 'mp2' | 'nellymoser' | 'opus' | 'pcm_alaw' | 'pcm_dvd' | 'pcm_f32be' | 'pcm_f32le' | 'pcm_f64be' | 'pcm_f64le' | 'pcm_mulaw' | 'pcm_s16be' | 'pcm_s16be_planar' | 'pcm_s16le' | 'pcm_s16le_planar' | 'pcm_s24be' | 'pcm_s24daud' | 'pcm_s24le' | 'pcm_s24le_planar' | 'pcm_s32be' | 'pcm_s32le' | 'pcm_s32le_planar' | 'pcm_s64be' | 'pcm_s64le' | 'pcm_s8' | 'pcm_s8_planar' | 'pcm_u16be' | 'pcm_u16le' | 'pcm_u24be' | 'pcm_u24le' | 'pcm_u32be' | 'pcm_u32le' | 'pcm_u8' | 'pcm_vidc' | 'ra_144' | 'roq_dpcm' | 's302m' | 'sbc' | 'sonic' | 'sonicls' | 'truehd' | 'tta' | 'vorbis' | 'wavpack' | 'wmav1' | 'wmav2';
+/**
+ * Defines all available video encoders of the
+ * ffmpeg base configuration.
+ */
+export type VideoEncoderBase = 'a64_multi' | 'a64_multi5' | 'alias_pix' | 'amv' | 'asv1' | 'asv2' | 'avrp' | 'avui' | 'ayuv' | 'bmp' | 'cinepak' | 'cljr' | 'dirac' | 'dnxhd' | 'dpx' | 'dvvideo' | 'ffv1' | 'ffvhuff' | 'fits' | 'flv1' | 'gif' | 'h261' | 'h263' | 'h263p' | 'huffyuv' | 'jpeg2000' | 'jpegls' | 'ljpeg' | 'magicyuv' | 'mjpeg' | 'mpeg1video' | 'mpeg2video' | 'mpeg4' | 'msmpeg4v2' | 'msmpeg4v3' | 'msvideo1' | 'pam' | 'pbm' | 'pcx' | 'pgm' | 'pgmyuv' | 'ppm' | 'prores' | 'qtrle' | 'r10k' | 'r210' | 'rawvideo' | 'roq' | 'rv10' | 'rv20' | 'sgi' | 'snow' | 'sunrast' | 'svq1' | 'targa' | 'tiff' | 'utvideo' | 'v210' | 'v308' | 'v408' | 'v410' | 'wmv1' | 'wmv2' | 'wrapped_avframe' | 'xbm' | 'xface' | 'xwd' | 'y41p' | 'yuv4';
+/**
+ * Defines the typing of the ffmpeg
+ * lgpl base configuration
+ */
+export type FFmpegConfiguration = IFFmpegConfiguration<ExtensionBase, AudioEncoderBase, VideoEncoderBase>;

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,0 +1,27 @@
+import * as types from './types';
+/**
+ * Get uint 8 array from a blob or url
+ */
+export declare const toUint8Array: (data: Blob | string) => Promise<Uint8Array>;
+/**
+ * Create local url for external script to
+ * work around cors issues
+ */
+export declare const toBlobURL: (url: string) => Promise<string>;
+/**
+ * Noop logger
+ */
+export declare const noop: (msg?: any, ...params: any[]) => void;
+/**
+ * Parse a ffmpeg progress event output
+ */
+export declare const parseProgress: (msg: string) => number;
+/**
+ * Parse a ffmpeg message and extract the meta
+ * data of the input
+ * @param data reference to the object that should
+ * recieve the data
+ * @returns Callback function that can be passed into
+ * the onMessage function
+ */
+export declare const parseMetadata: (data: types.Metadata) => (msg: string) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@diffusion-studio/ffmpeg-js",
-  "version": "0.0.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diffusion-studio/ffmpeg-js",
-      "version": "0.0.1",
+      "version": "0.2.3",
+      "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.35.1",
         "prettier": "2.8.8",

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -9,7 +9,7 @@ export class FFmpeg<
     string,
     string,
     string
-  > = types.FFmpegConfiguration
+  > = types.FFmpegConfiguration,
 > extends FFmpegBase {
   private _inputs: types.InputOptions[] = [];
   private _output?: types.OutputOptions<Config>;
@@ -71,7 +71,7 @@ export class FFmpeg<
       msg = msg.trim();
       let keys: [
         keyof types.SupportedCodecs,
-        keyof types.EncoderDecoderRecords
+        keyof types.EncoderDecoderRecords,
       ][] = [];
 
       if (!msg.match(/[DEVASIL\.]{6}\W(?!=)/)) return;
@@ -168,7 +168,7 @@ export class FFmpeg<
     this._middleware.push('-af', filter);
     if (this._inputs.length > 1) {
       throw new Error(
-        'Cannot use filters on multiple outputs, please use filterComplex instead'
+        'Cannot use filters on multiple outputs, please use filterComplex instead',
       );
     }
     return this;
@@ -182,7 +182,7 @@ export class FFmpeg<
     this._middleware.push('-vf', filter);
     if (this._inputs.length > 1) {
       throw new Error(
-        'Cannot use filters on multiple outputs, please use filterComplex instead'
+        'Cannot use filters on multiple outputs, please use filterComplex instead',
       );
     }
     return this;
@@ -203,6 +203,15 @@ export class FFmpeg<
    */
   public map(input: string): this {
     this._middleware.push('-map', input);
+    return this;
+  }
+
+  /**
+   * Append additional ffmpeg arguments that are not covered by
+   * the convenience methods.
+   */
+  public otherArgs(args: string[]): this {
+    this._middleware.push(...args);
     return this;
   }
 
@@ -247,7 +256,7 @@ export class FFmpeg<
   }
 
   /**
-   * Generate a series of thumbnails 
+   * Generate a series of thumbnails
    * @param source Your input file
    * @param count The number of thumbnails to generate
    * @param start Lower time limit in seconds
@@ -255,7 +264,7 @@ export class FFmpeg<
    * @example
    * // type AsyncGenerator<Blob, void, void>
    * const generator = ffmpeg.thumbnails('/samples/video.mp4');
-   * 
+   *
    * for await (const image of generator) {
    *    const img = document.createElement('img');
    *    img.src = URL.createObjectURL(image);
@@ -266,7 +275,7 @@ export class FFmpeg<
     source: string | Blob,
     count: number = 5,
     start: number = 0,
-    stop?: number
+    stop?: number,
   ): AsyncGenerator<Blob, void, void> {
     // make sure start and stop are defined
     if (!stop) {
@@ -276,7 +285,7 @@ export class FFmpeg<
       if (duration) stop = duration;
       else {
         console.warn(
-          'Could not extract duration from meta data please provide a stop argument. Falling back to 1sec otherwise.'
+          'Could not extract duration from meta data please provide a stop argument. Falling back to 1sec otherwise.',
         );
         stop = 1;
       }
@@ -300,7 +309,7 @@ export class FFmpeg<
       try {
         const res = await this.readFile('image.jpg');
         yield new Blob([res], { type: 'image/jpeg' });
-      } catch (e) { }
+      } catch (e) {}
     }
     this.clearMemory();
   }
@@ -333,7 +342,7 @@ export class FFmpeg<
   }
 
   private parseAudioOutput(
-    audio: types.OutputOptions<Config>['audio']
+    audio: types.OutputOptions<Config>['audio'],
   ): string[] {
     if (!audio) return [];
     if ('disableAudio' in audio) {
@@ -360,7 +369,7 @@ export class FFmpeg<
   }
 
   private parseVideoOutput(
-    video: types.OutputOptions<Config>['video']
+    video: types.OutputOptions<Config>['video'],
   ): string[] {
     if (!video) return [];
     if ('disableVideo' in video) {

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -109,8 +109,8 @@ test.describe('FFmpeg create command', async () => {
       command
         .join(' ')
         .startsWith(
-          '-i ccc.mp4 -vf rotate=90 -af silencedetect=noise=0.0001 -ss 10'
-        )
+          '-i ccc.mp4 -vf rotate=90 -af silencedetect=noise=0.0001 -ss 10',
+        ),
     ).toBe(true);
     expect(command.at(-1)?.endsWith('.m4v')).toBe(true);
   });
@@ -254,5 +254,25 @@ test.describe('FFmpeg create command', async () => {
     });
 
     expect(command.at(2)).toBe('-an');
+  });
+
+  test('test that other args can be appended', async () => {
+    const command = await page.evaluate(async () => {
+      return await ffmpeg
+        .input({ source: 'ccc.mp4' })
+        .otherArgs(['-progress', '-', '-v', 'error', '-y'])
+        .ouput({ format: 'm4v' })
+        .command();
+    });
+
+    const progIdx = command.indexOf('-progress');
+    expect(progIdx).toBeGreaterThan(-1);
+    expect(command[progIdx + 1]).toBe('-');
+
+    const vIdx = command.indexOf('-v');
+    expect(vIdx).toBeGreaterThan(-1);
+    expect(command[vIdx + 1]).toBe('error');
+
+    expect(command.includes('-y')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- allow passing arbitrary ffmpeg arguments via `otherArgs`
- document usage of `otherArgs`
- test additional arguments in command builder

## Testing
- `npm test` *(fails: request to https://registry.npmjs.org/playwright failed, reason: connect EHOSTUNREACH)*